### PR TITLE
avoid hardcoding `/scratch/`

### DIFF
--- a/lingua/distributed.py
+++ b/lingua/distributed.py
@@ -219,14 +219,6 @@ def setup_env(env_args):
     atexit.register(shutil.rmtree, triton_cache_dir, ignore_errors=True)
     env_vars["TRITON_CACHE_DIR"] = triton_cache_dir
 
-    # We change the tmp dir to /scratch in case it's slurm job
-    # This avoids filling up the host's usually limited tmpfs
-    # A full tmpfs leads to very slow creation of processes and weird bugs
-    if get_is_slurm_job():
-        new_tmp = f"/scratch/slurm_tmpdir/{os.environ['SLURM_JOB_ID']}"
-        if os.path.exists(new_tmp):
-            env_vars["TMP_DIR"] = new_tmp
-
     for name, value in env_vars.items():
         if os.environ.get(name) != str(value):
             os.environ[name] = str(value)


### PR DESCRIPTION
on slurm jobs, a `/scratch/slurm_tmpdir/` folder is attempted to be used for the `TMP_DIR` env var.

this is strange, given that
* `TMP_DIR` is not used anywhere else in the repository, nor is it a common env var name
* `/scratch/` does not exist in all slurm setups, and is an artefact of the author's personal cluster having their NFS at `/scratch/` specifically

therefore I propose deleting the code